### PR TITLE
Fix a bug for new files

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -74,7 +74,7 @@ self.addEventListener('fetch', function(e) {
 				// If the request is NOT in the cache, fetch and cache
 
 				var requestClone = e.request.clone();
-				fetch(requestClone)
+				return fetch(requestClone)
 					.then(function(response) {
 
 						if ( !response ) {


### PR DESCRIPTION
When a file wasn't cached, we were fetching and storing the response in cache but were not actually returning the response to the webpage. That resulted in the following error for the first time a file was accessed.
```
The FetchEvent for [url] resulted in a network error response: an object that was not a Response was passed to respondWith()
```